### PR TITLE
Elimination fix, user streak display fix, submission fix.

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -24,20 +24,7 @@ module UsersHelper
         elsif !user.dad_frequency.blank?
             postfrequency = user.dad_frequency
         else
-            postfrequency = "None"
-        end
-        
-        case postfrequency
-        when 1
-            "Daily"
-        when 2
-            "Every Other Day"
-        when 7
-            "Weekly"
-        when 0
-            "None"
-        else
-            "Every #{postfrequency} Days"
+            postfrequency = 0
         end
     end
     

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -30,14 +30,18 @@
     interval = setInterval(function() {
       currentTime = new Date(offset + Date.now());
       timeToNextDay = rubyNextDate - currentTime;
-      
-      seconds = Math.floor(timeToNextDay / (1000)) % 60;
-      minutes = Math.floor(timeToNextDay / (1000*60)) % 60;
-      hours = Math.floor(timeToNextDay / (1000*60*60)) % 24
-      days = Math.floor(timeToNextDay / (1000*60*60*24))
-      
-      $('#TimeDisplay').html(currentTime.toUTCString())
-      $('#NextDayDisplay').html(days+" day(s) "+pad(hours)+":"+pad(minutes)+":"+pad(seconds))
+    
+      if (timeToNextDay >= 0) { 
+        seconds = Math.floor(timeToNextDay / (1000)) % 60;
+        minutes = Math.floor(timeToNextDay / (1000*60)) % 60;
+        hours = Math.floor(timeToNextDay / (1000*60*60)) % 24
+        days = Math.floor(timeToNextDay / (1000*60*60*24))
+        
+        $('#TimeDisplay').html(currentTime.toUTCString())
+        $('#NextDayDisplay').html(days+" day(s) "+pad(hours)+":"+pad(minutes)+":"+pad(seconds))
+      } else {
+        $('#NextDayDisplay').html("0 day(s) 00:00:00")
+      }
     }, 1000);
   });
 </script>

--- a/app/views/submissions/_form.html.erb
+++ b/app/views/submissions/_form.html.erb
@@ -28,14 +28,18 @@
     interval = setInterval(function() {
       currentTime = new Date(offset + Date.now());
       timeToNextDay = rubyNextDate - currentTime;
-      
-      seconds = Math.floor(timeToNextDay / (1000)) % 60;
-      minutes = Math.floor(timeToNextDay / (1000*60)) % 60;
-      hours = Math.floor(timeToNextDay / (1000*60*60)) % 24
-      days = Math.floor(timeToNextDay / (1000*60*60*24))
-      
-      $('#TimeDisplay').html(currentTime.toUTCString())
-      $('#NextDayDisplay').html(days+" day(s) "+pad(hours)+":"+pad(minutes)+":"+pad(seconds))
+    
+      if (timeToNextDay >= 0) { 
+        seconds = Math.floor(timeToNextDay / (1000)) % 60;
+        minutes = Math.floor(timeToNextDay / (1000*60)) % 60;
+        hours = Math.floor(timeToNextDay / (1000*60*60)) % 24
+        days = Math.floor(timeToNextDay / (1000*60*60*24))
+        
+        $('#TimeDisplay').html(currentTime.toUTCString())
+        $('#NextDayDisplay').html(days+" day(s) "+pad(hours)+":"+pad(minutes)+":"+pad(seconds))
+      } else {
+        $('#NextDayDisplay').html("0 day(s) 00:00:00")
+      }
     }, 1000);
   });
 </script>
@@ -110,7 +114,7 @@
               <%= label_tag :postfrequency, "DAD Post Frequency" %>
             </div>
             <div class="col-9">
-              <%= select_tag :postfrequency, options_for_select([['Daily', 1], ['Every Other Day', 2], ['Every 3 Days', 3], ['Every 4 Days', 4], ['Every 5 Days', 5], ['Every 6 Days', 6], ['Weekly', 7]], (current_user.dad_frequency.blank? ? 1 : current_user.dad_frequency)), { :class => 'custom-select' } %>
+              <%= select_tag :postfrequency, options_for_select([['Daily', 1], ['Every Other Day', 2], ['Every 3 Days', 3], ['Every 4 Days', 4], ['Every 5 Days', 5], ['Every 6 Days', 6], ['Weekly', 7]], (getUserDADFrequency(current_user) == 0 ? 1 : getUserDADFrequency(current_user) )), { :class => 'custom-select' } %>
             </div>
           </div>
           

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -11,7 +11,7 @@
         <div class="card-body table-responsive" style="text-align: center;">
           <%= image_tag getUserThumb(@user) %><br><br>
           Longest Streak: <%= @user.longest_streak %><br>
-	  DAD Frequency: <%= getUserDADFrequency(@user) %>
+	        DAD Frequency: <%= postfrequencyToString(getUserDADFrequency(@user)) %>
           <% if logged_in? && current_user.id == @user.id %>
             <br><br>
             <a class="btn btn-primary" href="<%= edit_user_path(@user) %>">


### PR DESCRIPTION
The following quality of life fixes has been implemented:
Site next-day timer no longer freaks out at 00:00 GMT.
Submission form now automatically populates with your chosen post frequency if you are currently actively participating in DAD, rather than just being "Daily" by default.
Fixed a critical bug with the elimination handler that would've eliminated non-daily participants on the first day of their post period (should not have impacted anyone yet).
Fixed performance of elimination handler.