### PR TITLE
submissions.json supports to & from params and returns limited user data

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -6,14 +6,25 @@ class SubmissionsController < ApplicationController
   # GET /submissions.json
   def index
     @date = Date.current
-    if !params[:date].blank?
-      begin
-        @date = Date.parse(params[:date])
-      rescue ArgumentError
-        @date = Date.current
+
+    if !params[:to].blank? || !params[:from].blank?
+      if params[:to].blank?
+        @submissions = Submission.where("id >= :from", {from: params[:from]}).order('id ASC')
+      elsif params[:from].blank?
+        @submissions = Submission.where("id <= :to", {to: params[:to]}).order('id ASC')
+      else
+        @submissions = Submission.where(id: params[:from]..params[:to]).order('id ASC')
       end
+    else
+      if !params[:date].blank?
+        begin
+          @date = Date.parse(params[:date])
+        rescue ArgumentError
+          @date = Date.current
+        end
+      end
+      @submissions = Submission.where(created_at: @date.midnight..@date.end_of_day).order('created_at DESC')
     end
-    @submissions = Submission.where(created_at: @date.midnight..@date.end_of_day).order('created_at DESC')
   end
 
   # GET /submissions/1

--- a/app/views/submissions/_submission.json.jbuilder
+++ b/app/views/submissions/_submission.json.jbuilder
@@ -1,2 +1,8 @@
-json.extract! submission, :id, :drawing, :thumbnail, :nsfw_level, :created_at, :updated_at
+json.extract! submission, :id, :drawing, :nsfw_level, :created_at, :updated_at
 json.url submission_url(submission, format: :json)
+
+json.set! :user do
+  json.set! :id, submission.user.id
+  json.set! :name, submission.user.name
+  json.set! :avatar, submission.user.avatar
+end


### PR DESCRIPTION
Removed what I assume is old code in submissions.json so that it actually works, and added some basic user info in the json structure as well. Maybe there is a cleaner way to write this? Didn't find a way to cherry pick fields from a relationship in the query builder.

Added &to and &from params for the submissions index, mainly for use with the json resource, though they work just fine for the html page as well.