### PR TITLE
Removing external api commands

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -7,7 +7,3 @@
   background: image-url("seasonal/g1.png") ;
     background-repeat: no-repeat, repeat;
 }
-
-.inline-checkbox {
-    width: auto;
-}

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -187,7 +187,7 @@ class SubmissionsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def submission_params
-      params.require(:submission).permit(:drawing, :user_id, :nsfw_level, :api_command, :title, :description, :time, :commentable)
+      params.require(:submission).permit(:drawing, :user_id, :nsfw_level, :title, :description, :time, :commentable)
     end
   
     def limited_params

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -64,6 +64,6 @@ class UsersController < ApplicationController
 
   private
     def user_params
-      params.require(:user).permit(:name, :email, :password, :password_confirmation, :avatar, :nsfw_level, :enabled_api)
+      params.require(:user).permit(:name, :email, :password, :password_confirmation, :avatar, :nsfw_level)
     end
 end

--- a/app/views/submissions/_form.html.erb
+++ b/app/views/submissions/_form.html.erb
@@ -176,17 +176,6 @@
           </div>
         </div>
 
-        <% if @current_user.enabled_api %>
-          <div class="form-group row">
-            <div class="col-3">
-              <%= f.label :api_command, "API Command" %>
-            </div>
-            <div class="col-9">
-              <%= f.text_field :api_command, class: "form-control" %>
-            </div>
-          </div>
-        <% end %>
-
         <div class="form-group row">
           <div class="offset-sm-6 col-sm-6">
             <%= f.submit :class => 'btn btn-primary', :style => "margin-bottom: 0;" %>

--- a/app/views/submissions/_submission.json.jbuilder
+++ b/app/views/submissions/_submission.json.jbuilder
@@ -1,4 +1,4 @@
-json.extract! submission, :id, :drawing, :nsfw_level, :api_command, :created_at, :updated_at
+json.extract! submission, :id, :drawing, :nsfw_level, :created_at, :updated_at
 json.url submission_url(submission, format: :json)
 
 json.set! :user do

--- a/app/views/users/_editform.html.erb
+++ b/app/views/users/_editform.html.erb
@@ -72,10 +72,6 @@
             </div>
           <% end %>
 
-          <%= f.label :external_api do %>
-            <%= f.check_box :enabled_api, class: "inline-checkbox" %>
-            Enable External API
-          <% end %>
         </div>
       </div>
     </div>

--- a/db/migrate/20190112175052_remove_api_command_from_submissions.rb
+++ b/db/migrate/20190112175052_remove_api_command_from_submissions.rb
@@ -1,0 +1,5 @@
+class RemoveApiCommandFromSubmissions < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :submissions, :api_command
+  end
+end

--- a/db/migrate/20190112175423_remove_enabled_api_from_users.rb
+++ b/db/migrate/20190112175423_remove_enabled_api_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveEnabledApiFromUsers < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :users, :enabled_api
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181225191223) do
+ActiveRecord::Schema.define(version: 20190112175423) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -125,9 +125,8 @@ ActiveRecord::Schema.define(version: 20181225191223) do
     t.integer  "user_id"
     t.string   "drawing"
     t.integer  "nsfw_level"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
-    t.string   "api_command"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string   "title"
     t.string   "description"
     t.integer  "time"
@@ -148,7 +147,6 @@ ActiveRecord::Schema.define(version: 20181225191223) do
     t.boolean  "is_admin"
     t.integer  "dad_frequency"
     t.integer  "new_frequency"
-    t.boolean  "enabled_api"
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["name"], name: "index_users_on_name", unique: true, using: :btree
   end


### PR DESCRIPTION
I'll be shutting down ww3.lol which uses the external api from dad, so this is no longer needed.

Reject if you'd like to keep this functionality regardless of being used or not.