### PR TITLE
Delete notifications when their respective challenge/comment is deleted.

### DIFF
--- a/app/controllers/challenges_controller.rb
+++ b/app/controllers/challenges_controller.rb
@@ -166,7 +166,7 @@ class ChallengesController < ApplicationController
   end
 
   def destroy
-    return unless challenge.can_delete?
+    return unless @challenge.can_delete?
 
     Participation.where(challenge_id: @challenge.id).destroy_all
     Notification.where(source_type: 'Challenge', source_id: @challenge.id).destroy_all

--- a/app/controllers/challenges_controller.rb
+++ b/app/controllers/challenges_controller.rb
@@ -168,10 +168,6 @@ class ChallengesController < ApplicationController
   def destroy
     return unless @challenge.can_delete?
 
-    Participation.where(challenge_id: @challenge.id).destroy_all
-    Notification.where(source_type: 'Challenge', source_id: @challenge.id).destroy_all
-    @badge_map.destroy
-    @badge.destroy
     @challenge.destroy
     respond_to do |format|
       format.html { redirect_to challenges_url }

--- a/app/controllers/challenges_controller.rb
+++ b/app/controllers/challenges_controller.rb
@@ -169,6 +169,7 @@ class ChallengesController < ApplicationController
     return unless challenge.can_delete?
 
     Participation.where(challenge_id: @challenge.id).destroy_all
+    Notification.where(source_type: 'Challenge', source_id: @challenge.id).destroy_all
     @badge_map.destroy
     @badge.destroy
     @challenge.destroy

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -34,17 +34,22 @@ before_action :find_target
           next if @target.user_id == duid
 
           Notification.create(body: "#{poster_name} has also commented on submission #{@target.display_title} (ID #{@target.id}).",
-                              source_type: "Submission",
-                              source_id: @target.id,
+                              source_type: 'Comment',
+                              source_id: @comment.id,
                               user_id: duid,
                               url: submission_path(@target.id))
         end
         # Send a notification to the artist if it's not ourself.
-        Notification.create(body: "#{poster_name} has commented on your submission #{@target.display_title} (ID #{@target.id}).",
-                            source_type: "Submission",
-                            source_id: @target.id,
-                            user_id: @target.user_id,
-                            url: submission_path(@target.id)) unless @target.user_id == current_user.id
+        unless @target.user_id == current_user.id
+          Notification.create(
+            body: "#{poster_name} has commented on your submission #{@target.display_title} (ID #{@target.id}).",
+            source_type: 'Comment',
+            source_id: @comment.id,
+            user_id: @target.user_id,
+            # FIXME: The comment URL generation logic should be its own method.
+            url: submission_path(@target.id) + "\##{@comment.id}"
+          )
+        end
       end
       redirect_back(fallback_location: "/")
     else
@@ -64,6 +69,8 @@ before_action :find_target
         end
         target.num_comments -= 1
         target.save
+
+        Notification.where(source_type: 'Comment', source_id: id).destroy_all
       end
     else
       flash[:error] = "You can't delete other people's comments. Please cease these shenanigans."

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -69,8 +69,6 @@ before_action :find_target
         end
         target.num_comments -= 1
         target.save
-
-        Notification.where(source_type: 'Comment', source_id: id).destroy_all
       end
     else
       flash[:error] = "You can't delete other people's comments. Please cease these shenanigans."

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -46,8 +46,7 @@ before_action :find_target
             source_type: 'Comment',
             source_id: @comment.id,
             user_id: @target.user_id,
-            # FIXME: The comment URL generation logic should be its own method.
-            url: submission_path(@target.id) + "\##{@comment.id}"
+            url: @comment.url
           )
         end
       end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -26,7 +26,7 @@ class PagesController < ApplicationController
       comment_activity = Comment.order("created_at DESC").limit(10).includes(:user)
       comment_activity.each do |c|
         if c.source_type == "Submission"
-          activity_hash = { message: "#{c.user.username} posted a comment on submission #{c.source_id}.", datetime: c.created_at, link: submission_path(c.source_id) + "\##{c.id}" }
+          activity_hash = { message: "#{c.user.username} posted a comment on submission #{c.source_id}.", datetime: c.created_at, link: c.url }
           @activity.push(activity_hash)
         end
       end

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -26,7 +26,7 @@ class PagesController < ApplicationController
       comment_activity = Comment.order("created_at DESC").limit(10).includes(:user)
       comment_activity.each do |c|
         if c.source_type == "Submission"
-          activity_hash = { message: "#{c.user.username} posted a comment on submission #{c.source_id}.", datetime: c.created_at, link: submission_path(c.source_id) }
+          activity_hash = { message: "#{c.user.username} posted a comment on submission #{c.source_id}.", datetime: c.created_at, link: submission_path(c.source_id) + "\##{c.id}" }
           @activity.push(activity_hash)
         end
       end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -147,15 +147,8 @@ class SubmissionsController < ApplicationController
     # You can only delete a submission on the day you submitted it.
     return if @submission.created_at.to_date != Time.now.utc.to_date
 
-    ChallengeEntry.where(submission_id: @submission.id).destroy_all
     @submission.destroy
-
-    Comment.where(source: @submission).each do |comment|
-      # FIXME: Abstract this particular bit of code out into the model.
-      #   It should be `comment.notifications.destroy_all` or something like that.
-      #   Same for elsewhere this comes up: the challenge controller, @submission.comments, etc.
-      Notification.where(source_type: 'Comment', source_id: comment.id).destroy_all
-    end
+    @submission.comments.each { |comment| comment.notifications.destroy_all }
 
     respond_to do |format|
       format.html { redirect_to submissions_url }

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -149,6 +149,14 @@ class SubmissionsController < ApplicationController
 
     ChallengeEntry.where(submission_id: @submission.id).destroy_all
     @submission.destroy
+
+    Comment.where(source: @submission).each do |comment|
+      # FIXME: Abstract this particular bit of code out into the model.
+      #   It should be `comment.notifications.destroy_all` or something like that.
+      #   Same for elsewhere this comes up: the challenge controller, @submission.comments, etc.
+      Notification.where(source_type: 'Comment', source_id: comment.id).destroy_all
+    end
+
     respond_to do |format|
       format.html { redirect_to submissions_url }
       format.json { head :no_content }

--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -2,11 +2,12 @@
 
 # Represents a challenge on the website.
 class Challenge < ApplicationRecord
-  has_many :badge_maps
-  has_many :participations
+  has_many :badge_maps, dependent: :destroy
+  has_many :participations, dependent: :destroy
+  has_many :notifications, as: :source, dependent: :destroy
   has_many :challenge_entries
   has_many :users, through: :participations
-  has_many :badges, through: :badge_maps
+  has_many :badges, through: :badge_maps, dependent: :destroy
 
   NO_EXCESS_WHITESPACE = /\A(\S\s?)*\S\z/.freeze
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -8,6 +8,21 @@ class Comment < ApplicationRecord
   validates :user_id, presence: true
   validates :body, length: { maximum: 2000 }, presence: true
 
+  # FIXME: This code assumes that submissions are the only possible thing to comment on,
+  #   and although as far as I know that is *currently* true, the source is polymorphic,
+  #   so this should be rewritten to act on *any* source_type.
+  #   I don't know how to do it personally, but I assume there are two possibilities:
+  #     1. link_form does it somehow, and that code should be abstracted out to this method
+  #     2. link_form doesn't handle it, in which case it's probably safe to ignore for now
+  def url
+    "/submissions/#{source_id}\##{id}"
+  end
+
+  # HACK: What a mess!!
+  #   I *think* this parses comment bodies, finds `>>`-syntax replies,
+  #   and replaces them with links to the comment or submission being replied to.
+  #   I'd be willing to clean this up, but until I know for sure what it does,
+  #   I don't want to mess with it.
   def link_form
     return body if body.index('>>') == nil
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -3,6 +3,7 @@ class Comment < ApplicationRecord
 
   belongs_to :source, polymorphic: true
   belongs_to :user
+  has_many :notifications, as: :source, dependent: :destroy
 
   validates :user_id, presence: true
   validates :body, length: { maximum: 2000 }, presence: true

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -5,9 +5,14 @@ class Submission < ApplicationRecord
   mount_uploader :drawing, ImageUploader
 
   belongs_to :user
-  has_many :challenge_entries
+  has_many :challenge_entries, dependent: :destroy
   has_many :challenges, through: :challenge_entries
   has_many :comments, as: :source
+  # This *would* include a `dependent: :destroy` clause as well, but that causes an error:
+  #   Cannot modify association 'Submission#notifications'
+  #   because the source reflection class 'Notification' is associated to 'Comment' via :has_many.
+  # If there is any way to solve this, feel free to do so.
+  has_many :notifications, through: :comments
 
   validates :user_id, presence: true
   validates :drawing, presence: true


### PR DESCRIPTION
This is a WIP PR. So far I've implemented deletions of challenge notifications, which was a simple one-line change. I'm pretty sure it works, but I'd like to test it a bit more before it gets merged.

The same change for comments will be much more complicated due to a bug: comment submission notifications are created with `source_type: 'Submission'` and `source_id: @submission.id` rather than `source_type: 'Comment'` and `source_id: @comment.id`. Furthermore, the URL links to *just* the submission's URL rather than including the URL fragment to link to the specific comment.
These database issues must be corrected before the corresponding notification delete change can be implemented, because otherwise it is impossible to query to find the notifications which are associated with a comment.

How this change will be implemented still needs to be decided. I can think of two solutions:
1. Create further comment notifications correctly, and just accept that this change won't affect old comments.
2. Create a database migration which scrapes the comment ID out of the notification text, and corrects the source information and URL.

The third change that needs to be made is making the deletion of a submission delete notifications for comments associated with that submission. That could be done easily as-is (because the source is the submission), but considering that's about to be changed, that can be considered blocked on fixing the database issue for now.