### PR TITLE
Add moderator applications. (OLD VERSION)

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -44,6 +44,10 @@ header {
   height: 75px;
 }
 
+header.card-header {
+  height: auto;
+}
+
 .footer {
   font-size: 0.7rem;
   width: 100%;
@@ -505,4 +509,29 @@ p {
 .quote-id:hover {
   cursor: pointer;
   color: blue;
+}
+
+/*
+ * This application's CSS overwrites many default styles for some reason.
+ * This section will restore them back to their usual values within a section.
+ */
+
+.restore-defaults {
+  h1 {
+    font-size: 2em;
+    margin-top: 0.67em;
+    margin-bottom: 0.67em;
+    font-weight: bold;
+  }
+
+  h2 {
+    font-size: 1.5em;
+    margin-top: 0.83em;
+    margin-bottom: 0.83em;
+    font-weight: bold;
+  }
+
+  p {
+    margin: 1em 0px;
+  }
 }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,16 +6,28 @@ class ApplicationController < ActionController::Base
   before_action :set_raven_context
   before_action :record_user_session
 
+  def render_unauthenticated
+    render '/pages/unauthenticated', status: :forbidden
+  end
+
+  def render_unauthorized
+    render '/pages/unauthorized', status: :forbidden
+  end
+
+  def render_not_found
+    render file: "#{Rails.root}/public/404.html", status: :not_found
+  end
+
   # Check that if a user is logged in.
   def ensure_authenticated
     # Technically, the HTTP response code intended for unauthenticated requests is `401`.
     # However, to use it, you must support HTTP's authentication mechanism, which we don't.
-    render '/pages/unauthenticated', status: 403 unless logged_in?
+    render_unauthenticated unless logged_in?
   end
 
   # Check that the logged-in user is authorized to modify this submission.
   def ensure_authorized(creator_id)
-    render '/pages/unauthorized', status: 403 unless creator_id == current_user.id
+    render_unauthorized unless creator_id == current_user.id
   end
 
   private

--- a/app/controllers/challenges_controller.rb
+++ b/app/controllers/challenges_controller.rb
@@ -166,7 +166,7 @@ class ChallengesController < ApplicationController
   end
 
   def destroy
-    return unless challenge.can_delete?
+    return unless @challenge.can_delete?
 
     Participation.where(challenge_id: @challenge.id).destroy_all
     @badge_map.destroy

--- a/app/controllers/moderator_applications_controller.rb
+++ b/app/controllers/moderator_applications_controller.rb
@@ -1,0 +1,90 @@
+class ModeratorApplicationsController < ApplicationController
+  before_action :set_application, only: %i[show edit update destroy]
+  before_action :ensure_authenticated, only: %i[index show new create edit update destroy]
+  before_action :ensure_authorized_or_admin, only: %i[show edit update destroy]
+  before_action :ensure_applications_open, only: %i[show new create edit update destroy]
+  before_action :prevent_conflict, only: %i[new create]
+
+  def index
+    # Only the administrator can see moderator applications other than their own.
+    unless current_user.is_admin
+      if current_user.moderator_application
+        redirect_to current_user.moderator_application
+      else
+        redirect_to new_moderator_application_path
+      end
+      return
+    end
+
+    @applications = ModeratorApplication.all.order(created_at: :desc)
+  end
+
+  def show; end
+
+  def new
+    @application = ModeratorApplication.new
+  end
+
+  def edit; end
+
+  def create
+    @application = ModeratorApplication.new(application_params)
+    @application.user_id = current_user.id
+
+    view_result @application.save
+  end
+
+  def update
+    view_result @application.update(application_params)
+  end
+
+  def destroy
+    @application.destroy!
+
+    if current_user.is_admin
+      redirect_to moderator_applications_path
+    else
+      redirect_to root_url
+    end
+  end
+
+  private
+
+  def set_application
+    @application = ModeratorApplication.find_by(id: params[:id])
+
+    render_not_found if @application.nil?
+  end
+
+  def application_params
+    params.require(:moderator_application)
+          .permit(:at_least_18_years_old, :time_zone, :active_hours, :why_mod, :past_experience,
+                  :how_long, :why_dad, :anything_else)
+  end
+
+  def ensure_authorized_or_admin
+    # The administrator can view and edit *every* moderator application.
+    ensure_authorized @application.user_id unless current_user.is_admin
+  end
+
+  def ensure_applications_open
+    render_unauthorized unless ENV['MODERATOR_APPLICATIONS'] == 'open' || current_user.is_admin
+  end
+
+  # If someone has already submitted a moderator application,
+  # they should edit the existing one rather than creating a new one.
+  def prevent_conflict
+    return unless current_user.moderator_application
+
+    redirect_to edit_moderator_application_path(current_user.moderator_application)
+  end
+
+  def view_result(successful)
+    unless successful
+      render :new
+      return
+    end
+
+    redirect_to @application, status: :see_other
+  end
+end

--- a/app/models/moderator_application.rb
+++ b/app/models/moderator_application.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# Represents a moderator application.
+class ModeratorApplication < ApplicationRecord
+  belongs_to :user
+
+  # The ID of the user who is applying.
+  # Users may only have one moderator application each; however, they may edit it.
+  validates :user_id, presence: true, uniqueness: true
+  # The user must confirm that they are at least 18 years old.
+  # This data is not stored in the database, but the box must be checked on the form.
+  validates :at_least_18_years_old,
+            acceptance: { message: 'You must be at least 18 years old to apply to be a moderator.' }
+  # The user's time zone.
+  validates :time_zone, presence: { message: 'You must specify your time zone.' }
+  # The hours the user will most commonly be available to perform their duties.
+  validates :active_hours,
+            presence: { message: 'You must specify when you can actively moderate the site.' }
+  # Why the user wants to be a moderator.
+  validates :why_mod, presence: { message: 'You must explain why you should become a moderator.' }
+  # The user's past experience as a moderator.
+  validates :past_experience,
+            presence: { message: 'You state whether you have any past experience as a moderator.' }
+  # How long has the user been a member of LAS/DED/DAD.
+  validates :how_long, presence: { message: 'You must state how long you have been a member of DAD.'}
+  # What does dad mean to you?
+  validates :why_dad, presence: { message: 'You must explain what DAD means to you.' }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,7 @@ class User < ApplicationRecord
   has_many :badges, through: :awards
   has_many :challenges, through: :participations
   has_many :comments
+  has_one :moderator_application
 
   before_save { self.email = email.downcase }
 

--- a/app/views/challenges/index.html.slim
+++ b/app/views/challenges/index.html.slim
@@ -4,7 +4,7 @@
 
     .col-lg-8
       p.h2
-        | Challenge List
+        | Challenge List 
         a.btn.btn-primary style="margin-bottom: 0.5rem;" href="#{new_challenge_path}"
           span.fa.fa-plus
           |  Create Challenge

--- a/app/views/moderator_applications/_form.html.slim
+++ b/app/views/moderator_applications/_form.html.slim
@@ -1,0 +1,53 @@
+section.card
+  header.card-header
+    strong Moderator Application Form
+
+  .card-body
+    - if application.errors.any?
+      #error_explanation
+        h3 = "#{pluralize(application.errors.count, "error")} prohibited this application from being submitted:"
+        ul
+          - application.errors.messages.each do |message|
+            li = message[1][0]
+
+    p
+      | You will be able to edit your application after you submit it.
+      |  You may receive your response through the email address associated through your account.
+    br
+
+    = form_for application do |form|
+      .form-group.row
+        .col-3 = form.label(:at_least_18_years_old, 'Are you at least 18 years of age?')
+        .col-9 = form.check_box(:at_least_18_years_old, { checked: over_18, style: 'width: auto' })
+
+      .form-group.row
+        .col-3 = form.label(:time_zone, 'What time zone are you in?')
+        .col-9 = form.time_zone_select(:time_zone)
+
+      small style="color: grey;"
+        | Please state your answers in Central Standard Time.
+      .form-group.row
+        .col-3 = form.label(:active_hours, 'What periods of time can you be actively moderating the site?')
+        .col-9 = form.text_area(:active_hours)
+
+      .form-group.row
+        .col-3 = form.label(:why_mod, 'Why do you think you should become a mod?')
+        .col-9 = form.text_area(:why_mod)
+
+      .form-group.row
+        .col-3 = form.label(:past_experience, 'Do you have any past experience as a moderator?')
+        .col-9 = form.text_area(:past_experience)
+
+      .form-group.row
+        .col-3 = form.label(:how_long, 'How long have you been a member of LAS/DED/DAD?')
+        .col-9 = form.text_area(:how_long)
+
+      .form-group.row
+        .col-3 = form.label(:why_dad, 'What does DAD mean to you?')
+        .col-9 = form.text_area(:why_dad)
+
+      .form-group.row
+        .col-3 = form.label(:anything_else, 'Is there anything else you wish to include in your application? (Optional)')
+        .col-9 = form.text_area(:anything_else)
+
+      = form.submit 'Save Changes', class: 'btn btn-primary'

--- a/app/views/moderator_applications/_responsibilities.html.slim
+++ b/app/views/moderator_applications/_responsibilities.html.slim
@@ -1,0 +1,13 @@
+section.card
+  header.card-header
+    strong Moderator Responsibilities
+
+  .card-body
+    ul
+      li Viewing and passing judgment on explicit, offensive, or otherwise offputting materials.
+      li Actively surveying new users' submissions to ensure their integrity before approval.
+      li Read and act upon reports submitted by DAD users.
+      li Give warnings and bans based on criterion to be determined.
+      li Engaging in confidential discussions with fellow moderators.
+      li Making occasional public statements as the need arises.
+      li Maintaining strict integrity and objectivity in your conduct.

--- a/app/views/moderator_applications/edit.html.slim
+++ b/app/views/moderator_applications/edit.html.slim
@@ -1,0 +1,10 @@
+.container-fluid
+  .row
+    .col-lg-2
+
+    main.col-lg-8
+      h1 Edit Moderator Application
+      = render 'responsibilities'
+      = render 'form', application: @application, over_18: true
+
+    .col-lg-2

--- a/app/views/moderator_applications/index.html.slim
+++ b/app/views/moderator_applications/index.html.slim
@@ -1,0 +1,14 @@
+.container-fluid
+  .row
+    .col-lg-2
+
+    main.col-lg-8
+      h1 Moderator Applications
+      ul
+        - @applications.each do |application|
+          li
+            = link_to(application.user.username, moderator_application_path(application.id))
+            - if application.updated_at != application.created_at
+              = ", last updated #{application.updated_at.strftime("%b %-d, %Y at %H:%M")}"
+
+    .col-lg-2

--- a/app/views/moderator_applications/new.html.slim
+++ b/app/views/moderator_applications/new.html.slim
@@ -1,0 +1,10 @@
+.container-fluid
+  .row
+    .col-lg-2
+
+    main.col-lg-8
+      h1 New Moderator Application
+      = render 'responsibilities'
+      = render 'form', application: @application, over_18: false
+
+    .col-lg-2

--- a/app/views/moderator_applications/show.html.slim
+++ b/app/views/moderator_applications/show.html.slim
@@ -1,0 +1,38 @@
+.container-fluid
+  .row
+    .col-lg-2
+
+    main.restore-defaults.col-lg-8
+      h1
+        = link_to(@application.user.username, user_path(@application.user))
+        | 's Moderator Application
+
+      - if current_user.is_admin?
+        a.btn.btn-primary href=moderator_applications_path style='margin-right: 5px;'
+          span.fa.fa-undo Back
+      = link_to '<span class="fa fa-edit"></span>'.html_safe, edit_moderator_application_path(@application), class: 'btn btn-primary', style: 'margin-right: 5px;'
+      = link_to '<span class="fa fa-trash"></span>'.html_safe, @application, method: :delete, data: { confirm: 'Are you sure?' }, class: 'btn btn-primary'
+
+      h2.test What time zone are you in?
+      p = simple_format @application.time_zone
+
+      h2 What periods of time can you be actively moderating the site?
+      p = simple_format @application.active_hours
+
+      h2 Why do you think you should become a mod?
+      p = simple_format @application.why_mod
+
+      h2 Do you have any past experience as a moderator?
+      p = simple_format @application.past_experience
+
+      h2 How long have you been a member of LAS/DED/DAD?
+      p = simple_format @application.how_long
+
+      h2 What does DAD mean to you?
+      p = simple_format @application.why_dad
+
+      - unless @application.anything_else.nil? || @application.anything_else.empty?
+        h2 Is there anything else you wish to include in your application?
+        p = simple_format @application.anything_else
+
+    .col-lg-2

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,8 @@ Rails.application.routes.draw do
   end
   resources :users
   resources :challenges
-  resources :password_resets,     only: [:new, :create, :edit, :update]
+  resources :password_resets, only: [:new, :create, :edit, :update]
+  resources :moderator_applications
 
   resources :notifications, only: [:index] do
     collection do

--- a/db/migrate/20200513203600_create_moderator_applications.rb
+++ b/db/migrate/20200513203600_create_moderator_applications.rb
@@ -1,0 +1,15 @@
+class CreateModeratorApplications < ActiveRecord::Migration[6.0]
+  def change
+    create_table :moderator_applications do |t|
+      t.references :user, foreign_key: true
+      t.timestamps
+      t.string :time_zone
+      t.text :active_hours
+      t.text :why_mod
+      t.text :past_experience
+      t.text :how_long
+      t.text :why_dad
+      t.text :anything_else
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_22_233851) do
+ActiveRecord::Schema.define(version: 2020_05_13_203600) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,6 +77,20 @@ ActiveRecord::Schema.define(version: 2020_03_22_233851) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["source_type", "source_id"], name: "index_comments_on_source_type_and_source_id"
+  end
+
+  create_table "moderator_applications", force: :cascade do |t|
+    t.bigint "user_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.string "time_zone"
+    t.text "active_hours"
+    t.text "why_mod"
+    t.text "past_experience"
+    t.text "how_long"
+    t.text "why_dad"
+    t.text "anything_else"
+    t.index ["user_id"], name: "index_moderator_applications_on_user_id"
   end
 
   create_table "notifications", id: :serial, force: :cascade do |t|
@@ -175,5 +189,6 @@ ActiveRecord::Schema.define(version: 2020_03_22_233851) do
     t.index ["name"], name: "index_users_on_name", unique: true
   end
 
+  add_foreign_key "moderator_applications", "users"
   add_foreign_key "user_sessions", "users"
 end


### PR DESCRIPTION
Add moderator applications support, as requested.

Moderator applications may be enabled by setting the environment variable `MODERATOR_APPLICATIONS=open`. The administrator will still be able to access all moderator applications when this variable is not set, but users will not be able to submit, view, or modify their applications while it is disabled.

Currently, there is no mechanism to reply to or discuss moderator applications (i.e. there are no comments), so I state on the moderator application form that replies may come through the email associated with the user account. I wouldn't be surprised if you want to have me e.g. ask for their Discord username or something instead (because that's probably where you plan on hosting moderator chats).

I also added a `.restore-defaults` class to the CSS because something is messing with the margins and font of headers and paragraphs that makes them look *awful* when used conventionally, which is how I use them in `moderator_applications/show.html.slim`. `.restore-defaults` resets these styles to the defaults used by Firefox.

Finally, I don't link to the moderator applications page anywhere. I'm not sure if a change will be needed to create a link. Maybe you're planning on manually creating a notification about it? If so, the URL for that notification would be `/moderator_applications`, which will automatically link to the moderator application form, or to the user's existing moderator application if they have one.