### PR TITLE
Delete notifications when their subject is deleted.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Rails Tests
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:

--- a/app/controllers/challenges_controller.rb
+++ b/app/controllers/challenges_controller.rb
@@ -161,9 +161,6 @@ class ChallengesController < ApplicationController
   def destroy
     return unless @challenge.can_delete?
 
-    Participation.where(challenge_id: @challenge.id).destroy_all
-    @badge_map.destroy
-    @badge.destroy
     @challenge.destroy
     respond_to do |format|
       format.html { redirect_to challenges_url }

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class CommentsController < ApplicationController
+  include CommentsHelper
   include SubmissionsHelper
 
   before_action :set_target, only: %i[new create]
@@ -37,7 +38,7 @@ class CommentsController < ApplicationController
   end
 
   def destroy
-    target = Submission.find_by(id: @comment.source_id) if @comment.source_type == 'Submission'
+    target = @comment.source
     @comment.destroy!
     unless target.nil?
       target.num_comments -= 1
@@ -76,10 +77,10 @@ class CommentsController < ApplicationController
     Notification.create(
       body: format(message, poster: current_user.username,
                             target: "#{@target.display_title} (ID: #{@target.id})"),
-      source_type: 'Submission',
-      source_id: @target.id,
+      source_type: 'Comment',
+      source_id: @comment.id,
       user_id: user_id,
-      url: submission_path(@target)
+      url: comment_html_path(@comment)
     )
   end
 

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class PagesController < ApplicationController
+  include CommentsHelper
+
   def home
     @activeChallenges = Challenge.where('start_date <= ? AND (end_date > ? OR end_date IS NULL)', Date.current, Date.current).order('start_date ASC, end_date DESC')
     @upcomingChallenges = Challenge.where('start_date > ?', Date.current).order('start_date ASC, end_date DESC')
@@ -28,7 +30,7 @@ class PagesController < ApplicationController
     comment_activity = Comment.order('created_at DESC').limit(10).includes(:user)
     comment_activity.each do |c|
       if c.source_type == 'Submission'
-        activity_hash = { message: "#{c.user.username} posted a comment on submission #{c.source_id}.", datetime: c.created_at, link: submission_path(c.source_id) }
+        activity_hash = { message: "#{c.user.username} posted a comment on submission #{c.source_id}.", datetime: c.created_at, link: comment_html_path(c) }
         @activity.push(activity_hash)
       end
     end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -149,8 +149,9 @@ class SubmissionsController < ApplicationController
     # You can only delete a submission on the day you submitted it.
     return if @submission.created_at.to_date != Time.now.utc.to_date
 
-    ChallengeEntry.where(submission_id: @submission.id).destroy_all
     @submission.destroy
+    @submission.comments.each { |comment| comment.notifications.destroy_all }
+
     respond_to do |format|
       format.html { redirect_to submissions_url }
       format.json { head :no_content }

--- a/app/helpers/comments_helper.rb
+++ b/app/helpers/comments_helper.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module CommentsHelper
+  def comment_html_path(comment)
+    "#{url_for(comment.source)}\##{comment.id}"
+  end
+end

--- a/app/models/challenge.rb
+++ b/app/models/challenge.rb
@@ -2,11 +2,12 @@
 
 # Represents a challenge on the website.
 class Challenge < ApplicationRecord
-  has_many :badge_maps
-  has_many :participations
+  has_many :badge_maps, dependent: :destroy
+  has_many :participations, dependent: :destroy
+  has_many :notifications, as: :source, dependent: :destroy
   has_many :challenge_entries
   has_many :users, through: :participations
-  has_many :badges, through: :badge_maps
+  has_many :badges, through: :badge_maps, dependent: :destroy
 
   NO_EXCESS_WHITESPACE = /\A(\S\s?)*\S\z/.freeze
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -5,10 +5,16 @@ class Comment < ApplicationRecord
 
   belongs_to :source, polymorphic: true
   belongs_to :user
+  has_many :notifications, as: :source, dependent: :destroy
 
   validates :user_id, presence: true
   validates :body, length: { maximum: 2000 }, presence: true
 
+  # HACK: What a mess!!
+  #   I *think* this parses comment bodies, finds `>>`-syntax replies,
+  #   and replaces them with links to the comment or submission being replied to.
+  #   I'd be willing to clean this up, but until I know for sure what it does,
+  #   I don't want to mess with it.
   def link_form
     return body if body.index('>>').nil?
 

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -5,9 +5,14 @@ class Submission < ApplicationRecord
   mount_uploader :drawing, ImageUploader
 
   belongs_to :user
-  has_many :challenge_entries
+  has_many :challenge_entries, dependent: :destroy
   has_many :challenges, through: :challenge_entries
   has_many :comments, as: :source
+  # This *would* include a `dependent: :destroy` clause as well, but that causes an error:
+  #   Cannot modify association 'Submission#notifications'
+  #   because the source reflection class 'Notification' is associated to 'Comment' via :has_many.
+  # If there is any way to solve this, feel free to do so.
+  has_many :notifications, through: :comments
 
   validates :user_id, presence: true
   validates :drawing, presence: true


### PR DESCRIPTION
This should be good to merge. I know you said something about not knowing about if `dependent: :destroy` was the way you wanted to handle this, but if necessary disabling it should be as simple as removing it. Unless there's something more you'd like to discuss about it, in which case I'd like to hear.

Maybe I could write some tests before it's merged, but I still think this PR should be good to be merged.