### PR TITLE
Anonymous Comments on Discussions and Submissions.

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -21,6 +21,10 @@ class CommentsController < ApplicationController
     @comment.user_id = current_user.id
     @comment.body = @comment.body.gsub(/ +/, ' ').strip
 
+    unless @target.allow_anon
+      @comment.anonymous = false
+    end
+
     unless @comment.save
       flash[:error] = 'Comment failed to post: ' + @comment.errors.full_messages.join(', ')
       redirect_back(fallback_location: '/')
@@ -76,7 +80,7 @@ class CommentsController < ApplicationController
   private
 
   def comment_params
-    params.require(:comment).permit(:body, :user_id)
+    params.require(:comment).permit(:body, :user_id, :anonymous)
   end
 
   def set_target

--- a/app/controllers/discussions_controller.rb
+++ b/app/controllers/discussions_controller.rb
@@ -25,6 +25,12 @@ class DiscussionsController < ApplicationController
     @comment = @discussion.comments.new(comment_params)
     @comment.user_id = current_user.id
     @comment.body = @comment.body.gsub(/ +/, ' ').strip
+    @comment.anonymous = @discussion.anonymous
+
+    unless @discussion.allow_anon
+      @discussion.anonymous = false
+      @comment.anonymous = false
+    end
 
     respond_to do |format|
       if @comment.valid? && @discussion.valid?
@@ -44,10 +50,11 @@ class DiscussionsController < ApplicationController
   end
 
   def destroy
+    @alias = @discussion.board.alias
     @discussion.destroy
 
     respond_to do |format|
-      format.html { redirect_to discussions_url(@alias) }
+      format.html { redirect_to board_path(@alias) }
       format.json { head :no_content }
     end
   end
@@ -84,7 +91,7 @@ class DiscussionsController < ApplicationController
   end
 
   def discussion_params
-    params.require(:discussion).permit(:title, :nsfw_level)
+    params.require(:discussion).permit(:title, :nsfw_level, :allow_anon, :anonymous)
   end
 
   def comment_params

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -252,10 +252,10 @@ class SubmissionsController < ApplicationController
   # Never trust parameters from the scary internet, only allow the white list through.
   def submission_params
     params.require(:submission)
-          .permit(:drawing, :user_id, :nsfw_level, :title, :description, :time, :commentable)
+          .permit(:drawing, :user_id, :nsfw_level, :title, :description, :time, :commentable, :allow_anon)
   end
 
   def limited_params
-    params.require(:submission).permit(:nsfw_level, :title, :description, :commentable)
+    params.require(:submission).permit(:nsfw_level, :title, :description, :commentable, :allow_anon)
   end
 end

--- a/app/views/application/_comment.html.slim
+++ b/app/views/application/_comment.html.slim
@@ -1,0 +1,24 @@
+.card.comment-card id="#{comment.id}" class="#{"alert alert-danger" if comment.soft_deleted}" style="padding: 0px;"
+  .card-header
+    - if comment.anonymous
+      - if logged_in_as_moderator
+        b style="cursor: pointer;" data-toggle="tooltip" data-placement="top" title="Click to reveal name" onclick="javascript: this.hidden=true; document.getElementById('RevealedName#{comment.id}').hidden=false;" Anonymous
+        b id="RevealedName#{comment.id}" hidden=true = link_to comment.user.username, comment.user
+      - else
+        b Anonymous
+    - else
+      b = link_to comment.user.username, comment.user
+    = comment.created_at.strftime(" %H:%M, %b %-d, %Y") 
+    span.quote-id onclick=("quote(#{comment.id});" if has_permissions)
+      = " No. #{comment.id}"
+    - if comment.soft_deleted
+      b  - Soft Deleted by #{safe_username(comment.soft_deleted_by)} -
+    = link_to ' <span class="fa fa-trash"></span>'.html_safe, target_comment_path, method: :delete, data: { confirm: 'Are you sure?' } if comment.user_id == current_user&.id
+    | &nbsp;
+    - if logged_in_as_moderator
+      = form_with url: "#{target_comment_path}/mod_action", html: { style: 'width: auto; display: inline-block;' } do |f|
+        = f.text_field :reason, placeholder: "Reason", required: true, style: "width: 200px; display: inline-block; margin-bottom: 0px;"
+        = f.button "#{comment.soft_deleted ? "Undo Soft Delete" : "Soft Delete" }", name: 'toggle_soft_delete', class: "btn btn-sm btn-primary", style: "margin-left: 5px; line-height: 1;"
+
+  .card-body
+    = simple_format(comment.link_form)

--- a/app/views/application/_comment_entry.html.slim
+++ b/app/views/application/_comment_entry.html.slim
@@ -1,0 +1,24 @@
+.card
+  - if has_permissions
+    .card-header Reply To Thread
+
+    .card-body
+      | By commenting, you agree to adhere to DAD's guidelines for comment etiquette as defined 
+      a href="/help" here.
+      br
+      br
+      = form_for Comment.new, url: target_comments_path do |f|
+        = f.text_area :body, placeholder: "Please keep site rules in mind when posting.", onkeyup: "charcountupdate(this.value)", id: "comment-box"
+        span#charcount 0/2000
+
+        - if target.allow_anon
+          .form-group
+            = f.check_box :anonymous, style: "width: auto; margin-right: 0.5rem;"
+            = f.label :anonymous, "Post Anonymously"
+        
+        = f.submit "Post Comment"
+  - else
+    .card-header Reply To Thread
+
+    .card-body
+      = error

--- a/app/views/boards/show.html.slim
+++ b/app/views/boards/show.html.slim
@@ -23,6 +23,8 @@
               i.fa.fa-thumb-tack
             th
               i.fa.fa-lock
+            th
+              i.fa.fa-user-secret 
             th Name
             th Content
             th Posts
@@ -32,16 +34,19 @@
             - h.each do |t|
               tr
                 td
-                  - if t[:thread].pinned?
+                  - if t[:thread].pinned
                     i.fa.fa-thumb-tack
                 td
-                  - if t[:thread].locked?
+                  - if t[:thread].locked
                     i.fa.fa-lock
+                td
+                  - if t[:thread].allow_anon
+                    i.fa.fa-user-secret
                 td
                   = link_to t[:thread].title, t[:thread]
                 td #{nsfw_string(t[:thread].nsfw_level)}
                 td #{t[:num_comments]}
                 td
-                  = link_to "#{t[:last_reply].user.username} at #{relative_time_string(t[:last_reply].created_at)}", "#{url_for(t[:last_reply].source)}##{t[:last_reply].id}"
+                  = link_to "#{t[:last_reply].anonymous ? "Anonymous" : t[:last_reply].user.username} at #{relative_time_string(t[:last_reply].created_at)}", "#{url_for(t[:last_reply].source)}##{t[:last_reply].id}"
 
     .col-lg-2

--- a/app/views/discussions/_form.html.slim
+++ b/app/views/discussions/_form.html.slim
@@ -1,3 +1,14 @@
+javascript:
+  $(document).ready(function() {
+    document.getElementById('AllowAnonCheckbox').addEventListener('change', function(event) {
+      if (event.target.checked) {
+        document.getElementById('AnonymousRow').hidden = false
+      } else {
+        document.getElementById('AnonymousRow').hidden = true
+      }
+    })
+  })
+
 = form_for @discussion, html: { multipart: true } do |f|
   .row
     .col-lg-1
@@ -28,6 +39,14 @@
           .form-group.row
             .col-3 = f.label :nsfw_level
             .col-9 = f.select :nsfw_level, options_for_select([['Safe', 1], ['Questionable', 2], ['Explicit', 3]], @discussion.nsfw_level), {}, { class: 'custom-select' }
+
+          .form-group.row
+            .col-3 = f.label :allow_anon, "Allow Anonymous Replies?"
+            .col-9 = f.check_box :allow_anon, id: "AllowAnonCheckbox", style: "width: auto;"
+
+          #AnonymousRow.form-group.row hidden=true
+            .col-3 = f.label :anonymous, "Create Thread Anonymously?"
+            .col-9 = f.check_box :anonymous, style: "width: auto;"
 
       .card
         .card-header

--- a/app/views/discussions/show.html.slim
+++ b/app/views/discussions/show.html.slim
@@ -14,7 +14,7 @@ javascript:
           i.fa.fa-undo
           |  Back
         - if @discussion.user_id == current_user&.id
-          = link_to '<span class="fa fa-trash"></span>'.html_safe, discussion_path(@board.alias, @discussion), method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-primary", style: "margin-left: 5px;"
+          = link_to '<span class="fa fa-trash"></span>'.html_safe, discussion_path(@discussion), method: :delete, data: { confirm: 'Are you sure?' }, class: "btn btn-primary", style: "margin-left: 5px;"
         - if logged_in_as_moderator
           = form_with url: "#{discussion_path(@discussion)}/mod_action", html: { style: 'width: auto; display: inline-block;' } do |f|
             = f.button "", name: 'toggle_pinned', class: "btn #{@discussion.pinned ? 'btn-danger' : 'btn-primary'}", style: "margin-bottom: 0.5rem;" do |b|
@@ -30,42 +30,9 @@ javascript:
 
       - has_permissions, error = @discussion.can_be_commented_on_by(current_user)
 
-      .card
-        - if has_permissions
-          .card-header Reply To Thread
-
-          .card-body
-            | By commenting, you agree to adhere to DAD's guidelines for comment etiquette as defined 
-            a href="/help" here.
-            br
-            br
-            = form_for Comment.new, url: discussion_comments_path(@discussion) do |f|
-              = f.text_area :body, placeholder: "Please keep site rules in mind when posting.", onkeyup: "charcountupdate(this.value)", id: "comment-box"
-              span#charcount 0/2000
-              = f.submit "Post Comment"
-        - else
-          .card-header Reply To Thread
-
-          .card-body
-            = error
+      = render partial: "application/comment_entry", locals: { has_permissions: has_permissions, error: error, target: @discussion, target_comments_path: discussion_comments_path(@discussion) }
 
       - @comments.each do |comment|
-        .card.comment-card id="#{comment.id}" class="#{"alert alert-danger" if comment.soft_deleted}" style="padding: 0px;"
-          .card-header
-            b = link_to comment.user.username, comment.user
-            = comment.created_at.strftime(" %H:%M, %b %-d, %Y") 
-            span.quote-id onclick=("quote(#{comment.id});" if has_permissions)
-              = " No. #{comment.id}"
-            - if comment.soft_deleted
-              b  - Soft Deleted by #{safe_username(comment.soft_deleted_by)} -
-            = link_to ' <span class="fa fa-trash"></span>'.html_safe, [@discussion, comment], method: :delete, data: { confirm: 'Are you sure?' } if comment.user_id == current_user&.id
-            | &nbsp;
-            - if logged_in_as_moderator
-              = form_with url: "#{discussion_path(@discussion)}/comments/#{comment.id}/mod_action", html: { style: 'width: auto; display: inline-block;' } do |f|
-                = f.text_field :reason, placeholder: "Reason", required: true, style: "width: 200px; display: inline-block; margin-bottom: 0px;"
-                = f.button "#{comment.soft_deleted ? "Undo Soft Delete" : "Soft Delete" }", name: 'toggle_soft_delete', class: "btn btn-sm btn-primary", style: "margin-left: 5px; line-height: 1;"
-
-          .card-body
-            = simple_format(comment.link_form)
+          = render partial: "application/comment", locals: { comment: comment, target_comment_path: discussion_comment_path(@discussion, comment), has_permissions: has_permissions }
       
     .col-lg-2

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -317,16 +317,22 @@
                 <th>Forum Discussion</th>
               </thead>
               <tbody>
-                <% @forum_posts.each do |post| %>
+                <% @forum_activity.each do |activity| %>
                 <tr>
                   <td>
-                    <a style="color: white;" href="<%= post.source.present? ? "#{url_for(post.source)}##{post.id}" : "#" %>">  
-                      <% if post.source.present? %>
-                        <%= "#{post.user.username} replied to thread '#{post.source.title}'." %>
-                      <% else %>
-                        <%= "#{post.user.username} replied to a now deleted thread." %>
-                      <% end %>
-                    </a>
+                    <% if activity.is_a? Comment %>
+                      <a style="color: white;" href="<%= activity.source.present? ? "#{url_for(activity.source)}##{activity.id}" : "#" %>">  
+                        <% if activity.source.present? %>
+                          <%= "#{activity.anonymous ? 'Anonymous' : activity.user.username} replied to thread #{activity.source.title}." %>
+                        <% else %>
+                          <%= "#{activity.anonymous ? 'Anonymous' : activity.user.username} replied to a now deleted thread." %>
+                        <% end %>
+                      </a>
+                    <% elsif activity.is_a? Discussion %>
+                      <a style="color: white;" href="<%= discussion_path(activity) %>">
+                        <%= "#{activity.anonymous ? 'Anonymous' : activity.user.username} created the thread #{activity.title}." %>
+                      </a>
+                    <% end %>
                   </td>
                 </tr>
                 <% end %>

--- a/app/views/submissions/_editform.html.slim
+++ b/app/views/submissions/_editform.html.slim
@@ -7,6 +7,16 @@ javascript:
     $('[data-toggle="popover"]').popover()
   })
 
+  $(document).ready(function() {
+    document.getElementById('CommentableCheckbox').addEventListener('change', function(event) {
+      if (event.target.checked) {
+        document.getElementById('AllowAnonRow').hidden = false
+      } else {
+        document.getElementById('AllowAnonRow').hidden = true
+      }
+    })
+  })
+
 = form_for @submission, html: { multipart: true } do |f|
   .row
     .col-lg-6
@@ -54,7 +64,11 @@ javascript:
 
           .form-group.row
             .col-6 = f.label :commentable, "Allow Comments?"
-            .col-6 = f.check_box :commentable, checked: @submission.commentable
+            .col-6 = f.check_box :commentable, checked: @submission.commentable, id: "CommentableCheckbox"
+          
+          #AllowAnonRow.form-group.row hidden=( @submission.commentable ? nil : true )
+            .col-6 = f.label :allow_anon, "Allow Anonymous Comments?"
+            .col-6 = f.check_box :allow_anon, checked: @submission.allow_anon
 
           .form-group.row
             .offset-sm-6.col-sm-6 = f.submit class: 'btn btn-primary', style: "margin-bottom: 0;"

--- a/app/views/submissions/_form.html.slim
+++ b/app/views/submissions/_form.html.slim
@@ -96,7 +96,16 @@ javascript:
       }
 
     }, 1000);
+
+    document.getElementById('CommentableCheckbox').addEventListener('change', function(event) {
+      if (event.target.checked) {
+        document.getElementById('AllowAnonRow').hidden = false
+      } else {
+        document.getElementById('AllowAnonRow').hidden = true
+      }
+    })
   });
+
 
   // Paste image data from clipboard into submission
   window.addEventListener('paste', function (event) {
@@ -166,7 +175,11 @@ javascript:
 
           .form-group.row
             .col-6 = f.label :commentable, "Allow Comments?"
-            .col-6 = f.check_box :commentable, checked: "checked"
+            .col-6 = f.check_box :commentable, checked: "checked", id: "CommentableCheckbox"
+          
+          #AllowAnonRow.form-group.row
+            .col-6 = f.label :allow_anon, "Allow Anonymous Comments?"
+            .col-6 = f.check_box :allow_anon
 
           .form-group.row
             .offset-sm-6.col-sm-6 = f.submit class: 'btn btn-primary', style: "margin-bottom: 0;"

--- a/app/views/submissions/_partialeditform.html.slim
+++ b/app/views/submissions/_partialeditform.html.slim
@@ -1,3 +1,14 @@
+javascript:
+  $(document).ready(function() {
+    document.getElementById('CommentableCheckbox').addEventListener('change', function(event) {
+      if (event.target.checked) {
+        document.getElementById('AllowAnonRow').hidden = false
+      } else {
+        document.getElementById('AllowAnonRow').hidden = true
+      }
+    })
+  })
+
 = form_for @submission, html: { multipart: true } do |f|
   .row
     .col-lg-6
@@ -35,7 +46,11 @@
 
           .form-group.row
             .col-6 = f.label :commentable, "Allow Comments?"
-            .col-6 = f.check_box :commentable, checked: @submission.commentable
+            .col-6 = f.check_box :commentable, checked: @submission.commentable, id: "CommentableCheckbox"
+          
+          #AllowAnonRow.form-group.row hidden=( @submission.commentable ? nil : true )
+            .col-6 = f.label :allow_anon, "Allow Anonymous Comments?"
+            .col-6 = f.check_box :allow_anon, checked: @submission.allow_anon
 
           .form-group.row
             .offset-sm-6.col-sm-6 = f.submit class: 'btn btn-primary', style: "margin-bottom: 0;"

--- a/app/views/submissions/show.html.slim
+++ b/app/views/submissions/show.html.slim
@@ -157,40 +157,7 @@ javascript:
 
       - has_permissions, error = @submission.can_be_commented_on_by(current_user)
 
-      .card
-        - if has_permissions
-          .card-header Comment On Submission
-
-          .card-body
-            | By commenting, you agree to adhere to DAD's guidelines for comment etiquette as defined 
-            a href="/help" here.
-            br
-            br
-            = form_for [@submission, Comment.new] do |f|
-              = f.text_area :body, placeholder: "Write your comment. Do your best to provide meaningful feedback: a step above surface-level critique, simple praise, or a token acknowledgement of feedback.", onkeyup: "charcountupdate(this.value)", id: "comment-box"
-              span#charcount 0/2000
-              = f.submit "Post Comment"
-        - else
-          .card-header Comment On Submission
-
-          .card-body
-            = error
+      = render partial: "application/comment_entry", locals: { has_permissions: has_permissions, error: error, target: @submission, target_comments_path: submission_comments_path(@submission) }
 
       - @comments.each do |comment|
-        .card.comment-card id="#{comment.id}" class="#{"alert alert-danger" if comment.soft_deleted}" style="padding: 0px;"
-          .card-header
-            b = link_to comment.user.username, comment.user
-            = comment.created_at.strftime(" %H:%M, %b %-d, %Y") 
-            span.quote-id onclick=("quote(#{comment.id});" if has_permissions)
-              = " No. #{comment.id}"
-            - if comment.soft_deleted
-              b  - Soft Deleted by #{safe_username(comment.soft_deleted_by)} -
-            = link_to ' <span class="fa fa-trash"></span>'.html_safe, [@submission, comment], method: :delete, data: { confirm: 'Are you sure?' } if comment.user_id == current_user&.id
-            | &nbsp;
-            - if logged_in_as_moderator
-              = form_with url: "#{submission_path(@submission)}/comments/#{comment.id}/mod_action", html: { style: 'width: auto; display: inline-block;' } do |f|
-                = f.text_field :reason, placeholder: "Reason", required: true, style: "width: 200px; display: inline-block; margin-bottom: 0px;"
-                = f.button "#{comment.soft_deleted ? "Undo Soft Delete" : "Soft Delete" }", name: 'toggle_soft_delete', class: "btn btn-sm btn-primary", style: "margin-left: 5px; line-height: 1;"
-
-          .card-body
-            = simple_format(comment.link_form)
+        = render partial: "application/comment", locals: { comment: comment, target_comment_path: submission_comment_path(@submission, comment), has_permissions: has_permissions }

--- a/db/migrate/20201207233850_add_anonymous_to_comment.rb
+++ b/db/migrate/20201207233850_add_anonymous_to_comment.rb
@@ -1,0 +1,5 @@
+class AddAnonymousToComment < ActiveRecord::Migration[6.0]
+  def change
+    add_column :comments, :anonymous, :boolean, default: false
+  end
+end

--- a/db/migrate/20201208012412_add_allow_anon_to_submissions.rb
+++ b/db/migrate/20201208012412_add_allow_anon_to_submissions.rb
@@ -1,0 +1,5 @@
+class AddAllowAnonToSubmissions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :submissions, :allow_anon, :boolean, default: false
+  end
+end

--- a/db/migrate/20201208012425_add_allow_anon_to_discussions.rb
+++ b/db/migrate/20201208012425_add_allow_anon_to_discussions.rb
@@ -1,0 +1,5 @@
+class AddAllowAnonToDiscussions < ActiveRecord::Migration[6.0]
+  def change
+    add_column :discussions, :allow_anon, :boolean, default: false
+  end
+end

--- a/db/migrate/20201208041944_add_anonymous_to_discussion.rb
+++ b/db/migrate/20201208041944_add_anonymous_to_discussion.rb
@@ -1,0 +1,5 @@
+class AddAnonymousToDiscussion < ActiveRecord::Migration[6.0]
+  def change
+    add_column :discussions, :anonymous, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_05_020235) do
+ActiveRecord::Schema.define(version: 2020_12_08_041944) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -89,6 +89,7 @@ ActiveRecord::Schema.define(version: 2020_12_05_020235) do
     t.datetime "updated_at", null: false
     t.boolean "soft_deleted", default: false, null: false
     t.integer "soft_deleted_by"
+    t.boolean "anonymous", default: false
     t.index ["source_type", "source_id"], name: "index_comments_on_source_type_and_source_id"
   end
 
@@ -101,6 +102,8 @@ ActiveRecord::Schema.define(version: 2020_12_05_020235) do
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "board_id"
     t.boolean "pinned", default: false, null: false
+    t.boolean "allow_anon", default: false
+    t.boolean "anonymous", default: false
     t.index ["board_id"], name: "index_discussions_on_board_id"
     t.index ["user_id"], name: "index_discussions_on_user_id"
   end
@@ -233,6 +236,7 @@ ActiveRecord::Schema.define(version: 2020_12_05_020235) do
     t.boolean "soft_deleted", default: false, null: false
     t.boolean "approved", default: true, null: false
     t.integer "soft_deleted_by"
+    t.boolean "allow_anon", default: false
   end
 
   create_table "user_sessions", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
Anonymous posting is now available on the site!
When making a thread or a submission, you can now specify whether or not you wish to permit anonymous comments.
If you want to permit anonymous posts on a new thread, you can specify your opening post to be made anonymously.
By default, all existing threads/submissions before this change will be flagged to NOT permit anonymous comments.
PLEASE NOTE: Anonymous posting does not enable you to be exempt from punishment if you violate site rules. Moderators and administrators have the option to unveil your identity and apply suitable penalties based on your misconduct.
MODERATORS: To reveal an anonymous post, simply click on the "Anonymous" name to reveal the user responsible for the post.
DEVS: Comments and the comment form have been separated into their own partial for better reuseability.
Minor fixes: Fixed broken route on deleting a thread.