### PR TITLE
User dependencies updated in users so related follower entries are deleted

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,6 +25,8 @@ class User < ApplicationRecord
   has_many :moderator_logs, as: :target
   has_one :moderator_application
   has_many :house_participations, dependent: :nullify
+  has_many :followers, class_name: 'Follower', foreign_key: 'following_id', dependent: :destroy
+  has_many :following, class_name: 'Follower', foreign_key: 'user_id', dependent: :destroy
 
   before_save { self.email = email.downcase }
 


### PR DESCRIPTION
Fixes the bug where the edit profile page is broken because a user was deleted and rails can't find the related following_id.