### PR TITLE
Add developer role to user card and permissions

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -209,12 +209,12 @@ p {
 
     margin: 5px;
 
-    &.moderator {
-      background: #36458a;
-    }
-
     &.developer {
       background: #02690c;
+    }
+
+    &.moderator {
+      background: #36458a;
     }
 
     &.administrator {
@@ -249,12 +249,12 @@ p {
   background: #515d68;
   z-index: 1;
 
-  &.moderator {
-    background: #36458a;
-  }
-
   &.developer {
     background: #02690c;
+  }
+
+  &.moderator {
+    background: #36458a;
   }
 
   &.administrator {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -196,7 +196,7 @@ p {
 
 @media only screen and (max-width:620px)  {
   .container-fluid.mainPageSplash {
-  max-width:100%;
+    max-width:100%;
   }
 
   .page_info {
@@ -205,23 +205,22 @@ p {
 
   .avatarWithName {
     display: inline-block;
-    position: relative;
     width: 100%;
 
     margin: 5px;
-    border-radius: 10px;
-    background: #515d68;
-    z-index: 1;
 
     &.moderator {
       background: #36458a;
+    }
+
+    &.developer {
+      background: #02690c;
     }
 
     &.administrator {
       background: #8a4536;
     }
   }
-
 }
 
 .unselectable {
@@ -252,6 +251,10 @@ p {
 
   &.moderator {
     background: #36458a;
+  }
+
+  &.developer {
+    background: #02690c;
   }
 
   &.administrator {
@@ -607,4 +610,3 @@ p {
     margin: 1em 0px;
   }
 }
-

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -51,11 +51,7 @@ class ApplicationController < ActionController::Base
   end
 
   def ensure_clearance(permission_level)
-    if permission_level == 3
-      render_unauthorized unless current_user&.is_admin
-    elsif permission_level == 2
-      render_unauthorized unless current_user&.is_moderator || current_user&.is_admin
-    end
+    render_unauthorized unless current_user&.has_clearance?(permission_level)
   end
 
   def ensure_moderator

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -200,6 +200,21 @@ class User < ApplicationRecord
      challenges. Please wait until they are completed before you create another."]
   end
 
+  def has_clearance?(permission_level)
+    case permission_level
+    when 2
+      is_moderator || is_admin
+    when 3
+      is_admin
+    when 4
+      is_developer || is_admin
+    when 5
+      is_developer || is_moderator || is_admin
+    else
+      true
+    end
+  end
+
   def submission_limit
     max_dad_level = highest_level
     return 1 if max_dad_level.zero?

--- a/app/views/application/_usercard.html.slim
+++ b/app/views/application/_usercard.html.slim
@@ -1,12 +1,15 @@
-div class="avatarWithName #{'moderator' if user.is_moderator} #{'administrator' if user.is_admin}"
+div class="avatarWithName #{'moderator' if user.is_moderator} #{'administrator' if user.is_admin} #{'developer' if user.is_developer}"
   .avatarUserName
     = user.username
     br
-      - if user.is_moderator
-        span style="font-size: 10px;" Moderator
+      - if user.is_admin
+        span style="font-size: 10px" Administrator
         br
-      - elsif user.is_admin
-        span style="font-size: 10px;" Administrator
+      - elsif user.is_moderator
+        span style="font-size: 10px" Moderator
+        br
+      - elsif user.is_developer
+        span style="font-size: 10px" Developer
         br
       - if house.present?
         span style="font-size: 10px" of #{house.house_name}

--- a/app/views/boards/show.html.slim
+++ b/app/views/boards/show.html.slim
@@ -7,7 +7,7 @@
     .col-lg-8
       p.h2
         = @board.title
-        - unless (@board.permission_level == 3 && !current_user&.is_admin) || (@board.permission_level == 2 && (!current_user&.is_admin && !current_user&.is_moderator))
+        - if current_user&.has_clearance?(@board.permission_level)
           a.btn.btn-primary style="margin-left: 0.5rem; margin-bottom: 0.5rem;" href="#{new_discussion_path}?alias=#{@board.alias}"
             span.fa.fa-plus
             |  Create Thread
@@ -41,7 +41,7 @@
                     i.fa.fa-lock
                 td
                   - if t[:thread].allow_anon
-                    i.fa.fa-user-secret
+                    i.fa.fa-user-secret 
                 td
                   = link_to t[:thread].title, t[:thread]
                 td #{nsfw_string(t[:thread].nsfw_level)}

--- a/db/migrate/20210629000000_add_is_developer_to_users.rb
+++ b/db/migrate/20210629000000_add_is_developer_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIsDeveloperToUsers < ActiveRecord::Migration[6.0]
+  def change
+    add_column :users, :is_developer, :boolean, null: false, default: false
+  end
+end

--- a/db/migrate/20210822135112_renumber_permission_levels.rb
+++ b/db/migrate/20210822135112_renumber_permission_levels.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+class RenumberPermissionLevels < ActiveRecord::Migration[6.0]
+  def up
+    Board.all.each do |board|
+      case board.permission_level
+      when 0 # everyone
+        new_level = ~0
+      when 1 # everyone
+        new_level = ~0
+      when 2 # mods and admins
+        new_level = 0b11
+      when 3 # admins only
+        new_level = 0b1
+      else # no-one
+        new_level = 0
+      end
+      board.update_attributes!(:permission_level => new_level)
+    end
+  end
+
+  def down
+    Board.all.each do |board|
+      everyone_clearance = permission_level == ~0
+      admin_clearance    = permission_level.anybits?(1 << 0)
+      mod_clearance      = permission_level.anybits?(1 << 1)
+      if everyone_clearance
+        old_level = 1
+      elsif mod_clearance
+        old_level = 2
+      elsif admin_clearance
+        old_level = 3
+      else
+        # previous versions did not have "no clearance";
+        # just use admin clearance instead.
+        old_level = 3
+      end
+      board.update_attributes!(:permission_level => old_level)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_08_041944) do
+ActiveRecord::Schema.define(version: 2021_06_29_000000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -274,6 +274,7 @@ ActiveRecord::Schema.define(version: 2020_12_08_041944) do
     t.boolean "is_moderator", default: false, null: false
     t.boolean "approved", default: false, null: false
     t.boolean "marked_for_death", default: false, null: false
+    t.boolean "is_developer", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["name"], name: "index_users_on_name", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_29_000000) do
+ActiveRecord::Schema.define(version: 2021_08_22_135112) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
* Adds an `is_developer` column to the `users` table.
* Makes the user card of developers green (an arbitrary green with the same saturation and brightness as moderators. pic related; feel free to bikeshed).
* Adds two new permissions (e.g. for a development updates board): `4` for just admins and developers, and `5` for admins, moderators, or developers.

![developer user card](https://user-images.githubusercontent.com/25411849/123904762-e261a700-d925-11eb-945a-d2b0ba2c2cc7.png)

I'd prefer if it were more clear to users that developers do not have moderator permissions. Also, as one of the least consistent, lowest-skill members of the site I don't necessarily need the extra attention. Not saying that I *don't* want to have it either, but I'm kinda on the fence about it.