### PR TITLE
Quick fixes for crashes cause by challenges

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -23,8 +23,10 @@ class PagesController < ApplicationController
                              Date.today).order('prestige DESC').includes(:user)
     @latest_eliminations = Participation.where('challenge_id = 1 AND eliminated AND end_date = ?',
                                                (Date.current - 1.day)).order('score DESC').includes(:user)
-    @seasonal_leaderboard = Participation.where('challenge_id = ?',
+    unless @seasonal_challenge.nil?
+      @seasonal_leaderboard = Participation.where('challenge_id = ?',
                                                 @seasonal_challenge.id).order('score DESC').includes(:user)
+    end
 
     if logged_in?
       @participations = Participation.includes(challenge: [:challenge_entries])

--- a/app/views/application/_usercard.html.slim
+++ b/app/views/application/_usercard.html.slim
@@ -21,8 +21,8 @@ div class="avatarWithName #{'moderator' if user.is_moderator} #{'administrator' 
         - user_dad_score = user.current_streak
         .levelOverlay.unselectable
           - if user_dad_score != 0
-            - next_level = BadgeMap.where("required_score > #{user_dad_score} AND challenge_id = 1").order("required_score ASC").first
-            - prev_level = BadgeMap.where("required_score <= #{user_dad_score} AND challenge_id = 1").order("required_score DESC").first
+            - next_level = BadgeMap.joins(:challenge).where("badge_maps.required_score > #{user_dad_score} AND challenges.end_date is null").order("required_score ASC").first
+            - prev_level = BadgeMap.joins(:challenge).where("badge_maps.required_score <= #{user_dad_score} AND challenges.end_date  is null").order("required_score DESC").first
             = "#{user_dad_score}/#{next_level.required_score} to lvl #{next_level.prestige}"
           - else
             | No Active Streak

--- a/app/views/application/_usercard.html.slim
+++ b/app/views/application/_usercard.html.slim
@@ -21,8 +21,8 @@ div class="avatarWithName #{'moderator' if user.is_moderator} #{'administrator' 
         - user_dad_score = user.current_streak
         .levelOverlay.unselectable
           - if user_dad_score != 0
-            - next_level = BadgeMap.joins(:challenge).where("badge_maps.required_score > #{user_dad_score} AND challenges.end_date is null").order("required_score ASC").first
-            - prev_level = BadgeMap.joins(:challenge).where("badge_maps.required_score <= #{user_dad_score} AND challenges.end_date  is null").order("required_score DESC").first
+            - next_level = BadgeMap.where("required_score > #{user_dad_score} AND challenge_id = 1").order("required_score ASC").first
+            - prev_level = BadgeMap.where("required_score <= #{user_dad_score} AND challenge_id = 1").order("required_score DESC").first
             = "#{user_dad_score}/#{next_level.required_score} to lvl #{next_level.prestige}"
           - else
             | No Active Streak

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -149,18 +149,20 @@
           <% end %>
           <span><i class="fa fa-clock-o"></i> <span id="TimeDisplay"></span></span><br>
           <% currentSeason = Challenge.current_season %>
-          <span>
-            <% if currentSeason.name.include? "Spring" %>
-            <i class="fa fa-leaf"></i>
-            <% elsif currentSeason.name.include? "Summer" %>
-            <i class="fa fa-sun-o"></i>
-            <% elsif currentSeason.name.include? "Autumn" %>
-            <i class="fa fa-cloud"></i>
-            <% elsif currentSeason.name.include? "Winter" %>
-            <i class="fa fa-snowflake-o"></i>
-            <% end %>
-            <%= currentSeason.name %>: <%= pluralize((currentSeason.end_date - Date.current).to_i, "day") %> left.
-          </span>
+          <% unless currentSeason.nil? %>
+            <span>
+              <% if currentSeason.name.include? "Spring" %>
+              <i class="fa fa-leaf"></i>
+              <% elsif currentSeason.name.include? "Summer" %>
+              <i class="fa fa-sun-o"></i>
+              <% elsif currentSeason.name.include? "Autumn" %>
+              <i class="fa fa-cloud"></i>
+              <% elsif currentSeason.name.include? "Winter" %>
+              <i class="fa fa-snowflake-o"></i>
+              <% end %>
+              <%= currentSeason.name %>: <%= pluralize((currentSeason.end_date - Date.current).to_i, "day") %> left.
+            </span>
+          <% end %>
         </div>
       </div>
 


### PR DESCRIPTION
Fixes the homepage so it won't crash when seasonal challenges do not exist.
Also fixes an issue that will occur if the dad main challenge should change id.