### PR TITLE
Adding Open Graph Previews to Dad (#253)

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -23,8 +23,10 @@ class PagesController < ApplicationController
                              Date.today).order('prestige DESC').includes(:user)
     @latest_eliminations = Participation.where('challenge_id = 1 AND eliminated AND end_date = ?',
                                                (Date.current - 1.day)).order('score DESC').includes(:user)
-    @seasonal_leaderboard = Participation.where('challenge_id = ?',
+    unless @seasonal_challenge.nil?
+      @seasonal_leaderboard = Participation.where('challenge_id = ?',
                                                 @seasonal_challenge.id).order('score DESC').includes(:user)
+    end
 
     if logged_in?
       @participations = Participation.includes(challenge: [:challenge_entries])

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -13,6 +13,14 @@ html
     = csrf_meta_tags
 
     title = yield(:title)
+    - if content_for?(:head)
+      = yield :head
+    - else
+      // yield some default head params
+      meta property="og:title" content="Do Art Daily! A habit tracker for artists."
+      meta property="og:description" content="Do Art Daily is a site for developing artists to track their art progress and make a habit of drawing."
+      meta property="og:image" content="https://s3.us-east-2.amazonaws.com/do-art-daily-public/DAD+Badge.png"
+      meta property="og:url" content="#{request.original_url}"
 
   body
     #wrapper

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -149,18 +149,20 @@
           <% end %>
           <span><i class="fa fa-clock-o"></i> <span id="TimeDisplay"></span></span><br>
           <% currentSeason = Challenge.current_season %>
-          <span>
-            <% if currentSeason.name.include? "Spring" %>
-            <i class="fa fa-leaf"></i>
-            <% elsif currentSeason.name.include? "Summer" %>
-            <i class="fa fa-sun-o"></i>
-            <% elsif currentSeason.name.include? "Autumn" %>
-            <i class="fa fa-cloud"></i>
-            <% elsif currentSeason.name.include? "Winter" %>
-            <i class="fa fa-snowflake-o"></i>
-            <% end %>
-            <%= currentSeason.name %>: <%= pluralize((currentSeason.end_date - Date.current).to_i, "day") %> left.
-          </span>
+          <% unless currentSeason.nil? %>
+            <span>
+              <% if currentSeason.name.include? "Spring" %>
+              <i class="fa fa-leaf"></i>
+              <% elsif currentSeason.name.include? "Summer" %>
+              <i class="fa fa-sun-o"></i>
+              <% elsif currentSeason.name.include? "Autumn" %>
+              <i class="fa fa-cloud"></i>
+              <% elsif currentSeason.name.include? "Winter" %>
+              <i class="fa fa-snowflake-o"></i>
+              <% end %>
+              <%= currentSeason.name %>: <%= pluralize((currentSeason.end_date - Date.current).to_i, "day") %> left.
+            </span>
+          <% end %>
         </div>
       </div>
 

--- a/app/views/submissions/show.html.slim
+++ b/app/views/submissions/show.html.slim
@@ -1,5 +1,13 @@
 - provide(:title, "#{@submission.user.username} - #{@submission.display_title}")
 
+= content_for :head do
+  - if @submission.approved && !@submission.soft_deleted
+    meta property="og:title" content="Do Art Daily! #{@submission.display_title} by #{@submission.user.username}."
+    meta property="og:description" content="#{@submission.description}"
+    meta property="og:image" content="http://#{ENV["DAD_DOMAIN"]}#{@submission.drawing.url}"
+    meta property="og:url" content="#{request.original_url}"
+
+
 - psub = prev_submission(@submission)
 - apsub = prev_user_submission(@submission)
 - ansub = next_user_submission(@submission)

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -8,6 +8,13 @@ javascript:
     $('[data-toggle="tooltip"]').tooltip()
   })
 
+= content_for :head do
+  - unless SiteBan.where("user_id = #{@user.id} AND expiration > '#{Time.now.utc.to_date}'").exists? || !@user.approved
+    meta property="og:title" content="Do Art Daily! #{@user.username}"
+    meta property="og:description" content="User page of #{@user.username}"
+    meta property="og:image" content="#{@user.profile_picture}"
+    meta property="og:url" content="#{request.original_url}"
+    
 .container-fluid style="margin-top: 2rem;"
   .row
     .col-lg-1


### PR DESCRIPTION
* Stops seasonal challenges from breaking the homepage when they don't exist.
Also prevents the dad main challenge from breaking if the id should ever change.

* Added open graph links for users and submissions.
Added default OG properties to the main html.

* Small fix where the preview would not load for users who were previously banned, but their ban has expired.

* Reverted this fix for the main challenge. This will cause the site to break if the main challenge ever changes id.

Co-authored-by: nsix <nsix@cock.li>