### PR TITLE
Fix migration to account for negative creator id

### DIFF
--- a/app/helpers/challenges_helper.rb
+++ b/app/helpers/challenges_helper.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 module ChallengesHelper
-  def challenge_creator_link(id)
-    return 'Site Challenge' if id.blank?
+  def challenge_creator_link(challenge)
+    if challenge.creator_id.blank?
+      return 'Site Challenge' if challenge.is_site_challenge
 
-    return 'User Account Deleted' if id == -1
+      return 'User Account Deleted'
+    end
 
-    user = User.find(id)
+    user = User.find(challenge.creator_id)
     link_to(user.username, user)
   end
 

--- a/app/views/challenges/index.html.slim
+++ b/app/views/challenges/index.html.slim
@@ -38,7 +38,7 @@
               td = date_string_short(challenge.end_date)
               td = frequency_string(challenge.postfrequency, false)
               td = challenge.streak_based ? "Yes" : "No"
-              td = challenge_creator_link(challenge.creator_id)
+              td = challenge_creator_link(challenge)
               - if logged_in? && !challenge.creator_id.nil? && challenge.creator_id == current_user.id
                 td = link_to '<span class="fa fa-pencil"></span>'.html_safe, edit_challenge_path(challenge), class: "btn btn-primary"
               - else
@@ -55,7 +55,7 @@
               td = date_string_short(challenge.end_date)
               td = frequency_string(challenge.postfrequency, false)
               td = challenge.streak_based ? "Yes" : "No"
-              td = challenge_creator_link(challenge.creator_id)
+              td = challenge_creator_link(challenge)
               - if logged_in? && challenge.creator_id == current_user.id
                 td = link_to '<span class="fa fa-pencil"></span>'.html_safe, edit_challenge_path(challenge), class: "btn btn-primary"
                 - if challenge.can_delete?
@@ -74,7 +74,7 @@
               td = date_string_short(challenge.end_date)
               td = frequency_string(challenge.postfrequency, false)
               td = challenge.streak_based ? "Yes" : "No"
-              td = challenge_creator_link(challenge.creator_id)
+              td = challenge_creator_link(challenge)
               td
               td
 

--- a/db/migrate/20211024025226_add_user_relation_to_challenges.rb
+++ b/db/migrate/20211024025226_add_user_relation_to_challenges.rb
@@ -2,7 +2,31 @@
 
 # Adds a foreign key linking creator_id to users
 class AddUserRelationToChallenges < ActiveRecord::Migration[6.0]
-  def change
+  def up
+    add_column :challenges, :is_site_challenge, :boolean, null: false, default: false
+
+    # Before, creator_id = -1 indicates a deleted account, and nil indicates a site_challenge
+    Challenge.all.each do |challenge|
+      if challenge.creator_id.nil?
+        challenge.update!(is_site_challenge: true)
+      elsif challenge.creator_id == -1
+        challenge.update!(creator_id: nil)
+      end
+    end
+
     add_foreign_key :challenges, :users, column: :creator_id, primary_key: 'id'
+  end
+
+  def down
+    remove_foreign_key :challenges, column: :creator_id
+
+    Challenge.all.each do |challenge|
+      # if no creator_id, and not a site_challenge, clearly a deleted account
+      if challenge.creator_id.nil? && !challenge.is_site_challenge
+        challenge.update!(creator_id: -1)
+      end
+    end
+
+    remove_column :challenges, :is_site_challenge
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -77,6 +77,7 @@ ActiveRecord::Schema.define(version: 2021_12_05_074007) do
     t.integer "nsfw_level", default: 1, null: false
     t.boolean "soft_deleted", default: false, null: false
     t.integer "soft_deleted_by"
+    t.boolean "is_site_challenge", default: false, null: false
     t.index ["name"], name: "index_challenges_on_name"
   end
 
@@ -283,7 +284,6 @@ ActiveRecord::Schema.define(version: 2021_12_05_074007) do
     t.boolean "is_moderator", default: false, null: false
     t.boolean "approved", default: false, null: false
     t.boolean "marked_for_death", default: false, null: false
-    t.string "bio"
     t.boolean "is_developer", default: false, null: false
     t.boolean "marked_for_deletion", default: false, null: false
     t.date "deletion_date"

--- a/lib/tasks/dad_tasks.rake
+++ b/lib/tasks/dad_tasks.rake
@@ -384,7 +384,8 @@ namespace :dad_tasks do
     challenges = Challenge.where(creator_id: user_id)
     puts "Updating #{challenges.count} challenges..."
     challenges.each do |c|
-      c.creator_id = -1
+      c.creator_id = nil
+      c.is_site_challenge = true
       c.save
     end
 
@@ -428,6 +429,7 @@ namespace :dad_tasks do
       newChallenge.rejoinable = details['rejoinable']
       newChallenge.seasonal = details['seasonal']
       newChallenge.postfrequency = details['postfrequency']
+      newChallenge.is_site_challenge = true
       newChallenge.save
     end
 


### PR DESCRIPTION
Fix the migration so that it accounts for creator_id=-1 (the messy way deleted user accounts were accounted for).