### PR TITLE
WebM and MP4 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'jbuilder', '~> 2.0'
 # Gems for assisting with Image Upload on the site.
 gem 'carrierwave'
 gem 'mini_magick', '>= 4.9.4'
+gem 'carrierwave-video-thumbnailer'
 # Formating timestamps for site
 gem 'strftime', '~>1.0.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,8 @@ GEM
       mimemagic (>= 0.3.0)
       mini_mime (>= 0.1.3)
       ssrf_filter (~> 1.0)
+    carrierwave-video-thumbnailer (0.1.4)
+      carrierwave
     cloudflare-rails (2.2.0)
       actionpack (>= 5.2, < 7.1.0)
       activesupport (>= 5.2, < 7.1.0)
@@ -347,6 +349,7 @@ DEPENDENCIES
   bootstrap (>= 4.3.1)
   byebug
   carrierwave
+  carrierwave-video-thumbnailer
   cloudflare-rails (>= 2.2.0)
   coffee-rails (>= 5.0.0, < 5.1)
   database_cleaner-active_record (~> 1.8.0)

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -129,6 +129,12 @@ class SubmissionsController < ApplicationController
     # If the drawing itself was updated by an unapproved user, reset the approval.
     @submission.approved = current_user.approved if used_params.key? :drawing
 
+    # in case users switch from video to drawing or whatever
+    if used_params.key?(:drawing) || used_params.key?(:video)
+      @submission.drawing = nil
+      @submission.video = nil
+    end
+
     respond_to do |format|
       old_time = @submission.time || 0
       if @submission.update(used_params)
@@ -272,7 +278,7 @@ class SubmissionsController < ApplicationController
   # Never trust parameters from the scary internet, only allow the white list through.
   def submission_params
     params.require(:submission)
-          .permit(:drawing, :user_id, :nsfw_level, :title, :description, :time, :commentable, :allow_anon)
+          .permit(:video, :drawing, :user_id, :nsfw_level, :title, :description, :time, :commentable, :allow_anon)
   end
 
   def limited_params

--- a/app/helpers/submissions_helper.rb
+++ b/app/helpers/submissions_helper.rb
@@ -18,36 +18,48 @@ module SubmissionsHelper
     unless logged_in?
       return NSFW_THUMB if submission.nsfw_level > 1
 
-      return submission.drawing.thumb.url
+      return submission.drawing.thumb.url unless submission.drawing.thumb.url.nil?
+
+      return submission.video.thumb.url
     end
 
     return NSFW_THUMB if current_user.nsfw_level < submission.nsfw_level
 
-    submission.drawing.thumb.url
+    return submission.drawing.thumb.url unless submission.drawing.thumb.url.nil?
+
+    submission.video.thumb.url
   end
 
   def safe_submission_avatar(submission)
     unless logged_in?
       return NSFW_AVATAR if submission.nsfw_level > 1
 
-      return submission.drawing.avatar.url
+      return submission.drawing.avatar.url unless submission.drawing.avatar.url.nil?
+
+      return submission.video.avatar.url
     end
 
     return NSFW_AVATAR if current_user.nsfw_level < submission.nsfw_level
 
-    submission.drawing.avatar.url
+    return submission.drawing.avatar.url unless submission.drawing.avatar.url.nil?
+
+    submission.video.avatar.url
   end
 
   def safe_submission_drawing(submission)
     unless logged_in?
       return NSFW_THUMB if submission.nsfw_level > 1
 
-      return submission.drawing.url
+      return submission.drawing.url unless submission.drawing.url.nil?
+
+      submission.video.url
     end
 
     return NSFW_THUMB if current_user.nsfw_level < submission.nsfw_level
 
-    submission.drawing.url
+    return submission.drawing.url unless submission.drawing.url.nil?
+
+    submission.video.url
   end
 
   def unapproved_submissions
@@ -105,7 +117,8 @@ module SubmissionsHelper
 
   def random_safe_submission
     base_submissions(only_safe = true).where(
-      'submissions.nsfw_level = 1 and submissions.created_at >= ?', Time.now.utc - 14.days
+      'submissions.nsfw_level = 1 and submissions.created_at >= ? and drawing is not null',
+      Time.now.utc - 14.days
     ).sample
   end
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -6,6 +6,7 @@ class Submission < ApplicationRecord
   include MarkdownHelper
 
   mount_uploader :drawing, ImageUploader
+  mount_uploader :video, VideoUploader
 
   belongs_to :user
   has_many :challenge_entries, dependent: :destroy
@@ -19,7 +20,7 @@ class Submission < ApplicationRecord
   has_many :moderator_logs, as: :target
 
   validates :user_id, presence: true
-  validates :drawing, presence: true
+  validate :video_xor_drawing
   validates :title, length: { maximum: 100 }
   validates :description, length: { maximum: 2000 }
   validates :time, numericality: { only_integer: true, greater_than: 0, allow_nil: true }
@@ -62,5 +63,13 @@ class Submission < ApplicationRecord
     return 'No description provided.' if description.blank?
 
     description
+  end
+
+  private
+
+  def video_xor_drawing
+    return unless [drawing.file, video.file].compact.count != 1
+
+    errors.add(:base, 'You must upload either a drawing or a video (but not both).')
   end
 end

--- a/app/uploaders/video_uploader.rb
+++ b/app/uploaders/video_uploader.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# Used to upload webm and mp4s
+class VideoUploader < CarrierWave::Uploader::Base
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  include CarrierWave::Video  # for your video processing
+  include CarrierWave::Video::Thumbnailer
+  include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "submissions/#{model.user.name}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  version :thumb do
+    process thumbnail: [{format: 'png', quality: 10, size: 192, strip: true, logger: Rails.logger}]
+
+    def full_filename for_file
+      png_name for_file, version_name
+    end
+  end
+
+  version :avatar, from_version: :thumb do
+    process resize_to_fill: [50, 50]
+  end
+
+  def png_name for_file, version_name
+    %Q{#{version_name}_#{for_file.chomp(File.extname(for_file))}.png}
+  end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  def extension_whitelist
+    %w[mp4 webm]
+  end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/app/views/submissions/_editform.html.slim
+++ b/app/views/submissions/_editform.html.slim
@@ -64,11 +64,18 @@ javascript:
             h2.col-2 or
             input.col-4 type="text" maxlength="0" placeholder="Paste your drawing here"
 
+          .form-group.row id="video-row"
+            .col-3 style="font-weight: 600;" = f.label :video
+            br
+            .col-3 oninput="setPreview(event.target.files[0])" id="video" = f.file_field :video, style: "overflow: hidden;"
+            
           .form-group.row id="preview-row"
             .col-3 Preview:
-            img.col-9 id="drawing-preview" src="https://do-art-daily-public.s3.us-east-2.amazonaws.com/no_image.png" alt="[No File Selected]"
-
-
+            - if @submission.drawing.url.present?
+              img.col-9 id="drawing-preview" src="#{@submission.drawing.url}" alt="#{@submission.title}"
+            - else
+              img.col-9 id="drawing-preview" src="https://do-art-daily-public.s3.us-east-2.amazonaws.com/no_image.png" alt="[No File Selected]"
+            
           .form-group.row
             .col-3 style="font-weight:600;" = f.label :nsfw_level
             .col-9 = f.select :nsfw_level, options_for_select([['Safe', 1], ['Questionable', 2], ['Explicit', 3]], @submission.nsfw_level), {}, { class: 'custom-select' }

--- a/app/views/submissions/_form.html.slim
+++ b/app/views/submissions/_form.html.slim
@@ -152,6 +152,11 @@ javascript:
             .col-3 oninput="setPreview(event.target.files[0])" id="drawing" = f.file_field :drawing, style: "overflow: hidden;"
             h2.col-2 or
             input.col-4 type="text" maxlength="0"  placeholder="Paste your drawing here"
+            
+          .form-group.row id="video-row"
+            .col-3 style="font-weight: 600;" = f.label :video
+            br
+            .col-3 id="video" = f.file_field :video, style: "overflow: hidden;"
 
           .form-group.row id="preview-row"
             .col-3 Preview:

--- a/app/views/submissions/show.html.slim
+++ b/app/views/submissions/show.html.slim
@@ -121,7 +121,11 @@ javascript:
 
         .card-body style="text-align: center;"
           div style="width: 100%;"
-            = image_tag @submission.drawing.url, style: "max-width: 100%; max-height: 600px; cursor: zoom-in;", alt: "#{@submission.display_title}", id: "submissionImage"
+            - if @submission.drawing.url.nil?
+              = video_tag @submission.video.url, style: "max-width: 100%; max-height: 600px;", alt: "#{@submission.display_title}", id: "submissionVideo", controls: true, autoplay: true
+            - else
+              = image_tag @submission.drawing.url, style: "max-width: 100%; max-height: 600px; cursor: zoom-in;", alt: "#{@submission.display_title}", id: "submissionImage"
+              
           br
           = simple_format(@submission.link_form)
 

--- a/db/migrate/20220519025348_add_video_to_submission.rb
+++ b/db/migrate/20220519025348_add_video_to_submission.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+#Adds the video column to submissions
+class AddVideoToSubmission < ActiveRecord::Migration[6.0]
+  def change
+    add_column :submissions, :video, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_05_074007) do
+ActiveRecord::Schema.define(version: 2022_05_19_025348) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -77,7 +77,6 @@ ActiveRecord::Schema.define(version: 2021_12_05_074007) do
     t.integer "nsfw_level", default: 1, null: false
     t.boolean "soft_deleted", default: false, null: false
     t.integer "soft_deleted_by"
-    t.boolean "is_site_challenge", default: false, null: false
     t.index ["name"], name: "index_challenges_on_name"
   end
 
@@ -238,6 +237,7 @@ ActiveRecord::Schema.define(version: 2021_12_05_074007) do
     t.boolean "approved", default: true, null: false
     t.integer "soft_deleted_by"
     t.boolean "allow_anon", default: false
+    t.string "video"
   end
 
   create_table "user_feedbacks", force: :cascade do |t|
@@ -287,6 +287,7 @@ ActiveRecord::Schema.define(version: 2021_12_05_074007) do
     t.boolean "is_developer", default: false, null: false
     t.boolean "marked_for_deletion", default: false, null: false
     t.date "deletion_date"
+    t.string "bio", default: ""
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["name"], name: "index_users_on_name", unique: true
   end


### PR DESCRIPTION
   - Added the video field
   - Made it so that the submission image would appear if it already exists
 - _form.html.slim:
   - Added the video field
 - Gemfile:
   - Added CarrierWave video tools. Be sure to install ffmpegthumbnailer
 - Gemfile.lock
   - Same as above.
 - schema.rb:
   - Added the video column to submissions
 - show.html.slim:
   - Added the video tag if drawing is nil
 - submission.rb:
   - added the video uploader
   - added check to make sure video xor drawing are uploaded
 - submissions_controller.rb:
   - Modified edit to clear out video and drawing in case the user switches upload type
   - Added video to safe params
 - submissions_helper.rb:
   - Made sure to add video equivalent whenever drawing is nil
   - Made the random_safe_submission function only choose drawings
 - video_uploader.rb:
   - Uploader to handle videos and thumbnailing. Remember to install ffmpegthumbnailer

Also added a migration to add video to submissions.

Holding off until we have a not ugly solution to the new submission and edit submission page.