### PR TITLE
Notifies user they were replied to

### DIFF
--- a/app/assets/javascripts/comments/writing_utils.js
+++ b/app/assets/javascripts/comments/writing_utils.js
@@ -32,6 +32,6 @@ jQuery.fn.extend({
 });
 
 function quote(id) {
-  $("#comment-box").insertAtCaret(">>" + id.toString());
+  $("#comment-box").insertAtCaret(">>" + id.toString() + '\n');
   charcountupdate($("#comment-box").val());
 }

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -36,6 +36,8 @@ class CommentsController < ApplicationController
     end
 
     send_notifications
+    notify_replied_to
+
 
     flash[:success] = 'Comment posted successfully!'
     redirect_back(fallback_location: '/')
@@ -107,6 +109,20 @@ class CommentsController < ApplicationController
       user_id: user_id,
       url: comment_html_path(@comment)
     )
+  end
+
+  def notify_replied_to
+    user_ids = []
+    @comment.body.scan(/(?<=\>\>)\d+/).each do |c_id|
+
+      user_ids.append(Comment.find(c_id.to_i).user_id) if Comment.exists?(c_id.to_i)
+    end
+    user_ids.uniq.each do |user_id|
+      # Don't send notifications to ourselves.
+      next if user_id == current_user.id
+
+      send_notification('%<poster>s replied to your comment', user_id)
+    end
   end
 
   def send_notifications

--- a/app/models/discussion.rb
+++ b/app/models/discussion.rb
@@ -24,4 +24,8 @@ class Discussion < ApplicationRecord
 
     user.can_make_comments
   end
+
+  def display_title
+    title
+  end
 end


### PR DESCRIPTION
Notifications are sent to users when their comment is replied to. Users only get 1 notification per reply. Users can't notify themselves, and cases where the comment being replied to doesn't exist are handled.

In the video below, I am logged in as two separate users in each tab.

https://github.com/user-attachments/assets/b1eaa614-d80f-4693-9f6e-45661f8714ab

